### PR TITLE
5.4.1 snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 ## Notice
 
+- uiautomator2 can not allow 'app' in capabilities to be empty from v2.30.0. Use v2.29.11 or earlier.
 - iOS 17 is not supported yet.
 
 ## Document

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 }
 
 group = "io.github.ldi-github"
-version = "5.4.0"
+version = "5.4.1-SNAPSHOT"
 
 val appiumClientVersion = "8.5.1"
 

--- a/build/generated/source/buildConfig/main/main/io/github/ldi_github/shirates_core/BuildConfig.kt
+++ b/build/generated/source/buildConfig/main/main/io/github/ldi_github/shirates_core/BuildConfig.kt
@@ -5,7 +5,7 @@ import kotlin.String
 object BuildConfig {
     const val appName: String = "shirates-core"
 
-    const val version: String = "5.4.0"
+    const val version: String = "5.4.1-SNAPSHOT"
 
     const val packageName: String = "io.github.ldi-github"
 

--- a/doc/markdown/quick-start.md
+++ b/doc/markdown/quick-start.md
@@ -118,26 +118,6 @@ npm install -g appium
 appium -v
 ```
 
-#### Example
-
-```
-wave1008@SNB-M1 ~ % appium -v
-2.0.1
-wave1008@SNB-M1 ~ % npm uninstall -g appium
-
-removed 483 packages in 890ms
-wave1008@SNB-M1 ~ % npm install -g appium
-npm WARN deprecated typedoc-plugin-resolve-crossmodule-references@0.3.3: Upgrade to typedoc >= 0.24 and remove typedoc-plugin-resolve-crossmodule-references from your dependencies
-
-added 483 packages in 4s
-
-57 packages are looking for funding
-  run `npm fund` for details
-wave1008@SNB-M1 ~ % appium -v
-2.1.3
-wave1008@SNB-M1 ~ % 
-```
-
 <br>
 
 ### UIAutomator2 driver
@@ -145,7 +125,7 @@ wave1008@SNB-M1 ~ %
 Install UIAutomator2 driver.
 
 ```
-appium driver install uiautomator2
+appium driver install uiautomator2@2.29.11
 ```
 
 <br>
@@ -154,7 +134,7 @@ If you have already installed the driver, uninstall it and install it again.
 ```
 appium driver list
 appium driver uninstall uiautomator2
-appium driver install uiautomator2
+appium driver install uiautomator2@2.29.11
 appium driver list
 ```
 

--- a/doc/markdown/quick-start_ja.md
+++ b/doc/markdown/quick-start_ja.md
@@ -117,26 +117,6 @@ npm install -g appium
 appium -v
 ```
 
-#### Example
-
-```
-wave1008@SNB-M1 ~ % appium -v
-2.0.1
-wave1008@SNB-M1 ~ % npm uninstall -g appium
-
-removed 483 packages in 890ms
-wave1008@SNB-M1 ~ % npm install -g appium
-npm WARN deprecated typedoc-plugin-resolve-crossmodule-references@0.3.3: Upgrade to typedoc >= 0.24 and remove typedoc-plugin-resolve-crossmodule-references from your dependencies
-
-added 483 packages in 4s
-
-57 packages are looking for funding
-  run `npm fund` for details
-wave1008@SNB-M1 ~ % appium -v
-2.1.3
-wave1008@SNB-M1 ~ % 
-```
-
 <br>
 
 ### UIAutomator2 driver
@@ -144,7 +124,7 @@ wave1008@SNB-M1 ~ %
 UIAutomator2ドライバーをインストールしてください。
 
 ```
-appium driver install uiautomator2
+appium driver install uiautomator2@2.29.11
 ```
 
 <br>
@@ -153,7 +133,7 @@ appium driver install uiautomator2
 ```
 appium driver list
 appium driver uninstall uiautomator2
-appium driver install uiautomator2
+appium driver install uiautomator2@2.29.11
 appium driver list
 ```
 

--- a/doc/markdown/updating_packages/installing_updating_appium&drivers.md
+++ b/doc/markdown/updating_packages/installing_updating_appium&drivers.md
@@ -27,7 +27,7 @@ See [Tested Environments](../environments.md) to get tested version.
 ### Installing
 
 ```
-appium driver install uiautomator2
+appium driver install uiautomator2@2.29.11
 appium driver list
 ```
 
@@ -36,7 +36,7 @@ appium driver list
 ```
 appium driver list
 appium driver uninstall uiautomator2
-appium driver install uiautomator2
+appium driver install uiautomator2@2.29.11
 appium driver list
 ```
 
@@ -82,7 +82,7 @@ npm install -g appium
 appium driver uninstall uiautomator2
 appium driver uninstall xcuitest
 
-appium driver install uiautomator2
+appium driver install uiautomator2@2.29.11
 appium driver install xcuitest
 
 appium -v

--- a/doc/markdown/updating_packages/installing_updating_appium&drivers_ja.md
+++ b/doc/markdown/updating_packages/installing_updating_appium&drivers_ja.md
@@ -27,7 +27,7 @@ appium -v
 ### インストール
 
 ```
-appium driver install uiautomator2
+appium driver install uiautomator2@2.29.11
 appium driver list
 ```
 
@@ -36,7 +36,7 @@ appium driver list
 ```
 appium driver list
 appium driver uninstall uiautomator2
-appium driver install uiautomator2
+appium driver install uiautomator2@2.29.11
 appium driver list
 ```
 
@@ -82,7 +82,7 @@ npm install -g appium
 appium driver uninstall uiautomator2
 appium driver uninstall xcuitest
 
-appium driver install uiautomator2
+appium driver install uiautomator2@2.29.11
 appium driver install xcuitest
 
 appium -v

--- a/doc/template/testrun.global.properties
+++ b/doc/template/testrun.global.properties
@@ -74,6 +74,7 @@ ios.profile=iOS *
 emulatorOptions=-no-boot-anim -no-snapshot
 #deviceStartupTimeoutSeconds=
 #deviceWaitSecondsAfterStartup=
+#enableWdaInstallOptimization=false
 
 ## Appium --------------------
 appiumServerUrl=http://127.0.0.1:4720/


### PR DESCRIPTION
uiautomator2 can not allow 'app' in capabilities to be empty from v2.30.0. Use v2.29.11 or earlier.